### PR TITLE
Convert integer cast to round() for safety

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -20,7 +20,7 @@ void calculate_derived_inputs( Input * I )
 
 	I->ntracks_2D = 2 * ( I->ntracks_2D / 2 );
 
-	I->z_stacked = (int) ( I->height / (I->axial_z_sep * I->decomp_assemblies_ax));
+	I->z_stacked = round ( I->height / (I->axial_z_sep * I->decomp_assemblies_ax));
 	I->ntracks = I->ntracks_2D * I->n_polar_angles * I->z_stacked;  
 	I->domain_height = I->height / I->decomp_assemblies_ax;
 


### PR DESCRIPTION
Fix for a verification error on AMD EPYC system using a Cray compiler version 15. Building with -Ofast exposed the problem.
Using these inputs:
```
axial z-ray separation:            0.25
assemblies per axial sub-domain:   20
reactor height:                    400.00
```
On the system under test, the `I->z_stacked` was 79.999992 which was casted down to 79. Using `round()` fixed this so `I->z_stacked` computes to 80.